### PR TITLE
Use `importlib.import_module` instead of `__import__`.

### DIFF
--- a/bin/whichpkg
+++ b/bin/whichpkg
@@ -6,6 +6,7 @@ __version__ = '0.3.0'
 if __name__ == '__main__':
     import sys
     import re
+    from importlib import import_module
 
     if len(sys.argv) == 1:
         sys.exit(0)
@@ -14,7 +15,7 @@ if __name__ == '__main__':
 
     for pkg in sys.argv[1:]:
         try:
-            f = __import__(pkg).__file__
+            f = import_module(pkg).__file__
             f = re.sub(r'\.pyc$', '.py', f)  # .pyc to .py
             f = re.sub(r'__init__\.py$', '', f)  # Drop an __init__.py
             sys.stdout.write('{0}\n'.format(f))


### PR DESCRIPTION
Before:

```
ted@aventador-3 % bin/whichpkg logging.handlers
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/
```

After:

```
ted@aventador-3 % bin/whichpkg logging.handlers
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/handlers.py
```
