### PR TITLE
Exit with error status if there are no parameters.

### DIFF
--- a/bin/whichpkg
+++ b/bin/whichpkg
@@ -9,7 +9,7 @@ if __name__ == '__main__':
     from importlib import import_module
 
     if len(sys.argv) == 1:
-        sys.exit(0)
+        sys.exit(1)
 
     failed = False
 


### PR DESCRIPTION
It might make sense to add a usage message here too.
